### PR TITLE
gh-3: integrate API and MongoDB

### DIFF
--- a/back/config.js
+++ b/back/config.js
@@ -12,16 +12,13 @@ const config = {
     projectName: 'Peerplays Block Explorer Backend',
     logLevel: "info",
     port: { api: 8000 },
-    hapiMongoModels: {
-        mongodb: {
-            uri: {
-                $filter: 'env',
-                production: process.env.MONGODB_URI,
-                test: 'mongodb://localhost:27017/pbsa',
-                $default: 'mongodb://localhost:27017/pbsa'
-            }
-        },
-        autoIndex: true
+    mongodb: {
+        uri: {
+            $filter: 'env',
+            production: process.env.MONGODB_URI,
+            test: 'mongodb://localhost:27017/private_test',
+            $default: 'mongodb://localhost:27017/private_test'
+        }
     },
 };
 

--- a/back/index.js
+++ b/back/index.js
@@ -1,6 +1,8 @@
 'use strict';
+const Config = require('./config');
 const Glue = require('glue');
 const Manifest = require('./manifest');
+const Mongoose = require('mongoose');
 const Log = require('./server/utils/logger');
 
 
@@ -12,6 +14,16 @@ exports.deployment = async (start) => {
         return server;
     }
     await server.start();
+
+    let mongoUri =  Config.get('/mongodb/uri');
+
+    Mongoose.connect(mongoUri, {}).then(() => {
+        Log.info(`Connected to ${mongoUri}`);
+    },
+    err => {
+        Log.error(err);
+    });
+
     Log.info(`Server started at ${server.info.uri}`);
     return server;
 };

--- a/back/manifest.js
+++ b/back/manifest.js
@@ -20,7 +20,7 @@ const manifest = {
     register: {
         plugins: [
             {
-                plugin: './server/api/block',
+                plugin: './server/api/blocks',
                 routes: {
                     prefix: '/api'
                 }

--- a/back/package.json
+++ b/back/package.json
@@ -25,7 +25,10 @@
     "dotenv": "^4.0.0",
     "glue": "^5.0.0",
     "hapi": "^17.2.0",
-    "joi": "^13.1.0"
+    "joi": "^13.1.0",
+    "joigoose": "^4.0.0",
+    "mongoose": "^5.0.1",
+    "mongoose-paginate": "^5.0.3"
   },
   "devDependencies": {
     "nodemon": "^1.14.11"

--- a/back/server/api/block.js
+++ b/back/server/api/block.js
@@ -1,11 +1,31 @@
 'use strict';
 
+const Block = require('../models/Block');
+const Joi = require('joi');
+
 exports.register = function (server, options) {
   server.route({
       method: 'GET',
       path: '/block',
-      handler: function (request, h) {
-          return { message: 'test' };
+      config: {
+          validate: {
+              query: {
+                  sort: Joi.string().default('_id'),
+                  "page[offset]": Joi.number().positive().default(0),
+                  "page[limit]": Joi.number().positive().max(100).default(20)
+              }
+          }
+      },
+      handler: async function (request, h) {
+          var query = {};
+          var options = {
+              sort: request.query.sort,
+              populate: 'author',
+              lean: true,
+              offset: request.query['page[offset]'],
+              limit: request.query['page[limit]']
+          };
+          return await Block.paginate(query, options);
       }
   });
 };

--- a/back/server/api/blocks.js
+++ b/back/server/api/blocks.js
@@ -6,7 +6,7 @@ const Joi = require('joi');
 exports.register = function (server, options) {
   server.route({
       method: 'GET',
-      path: '/block',
+      path: '/blocks',
       config: {
           validate: {
               query: {
@@ -25,7 +25,9 @@ exports.register = function (server, options) {
               offset: request.query['page[offset]'],
               limit: request.query['page[limit]']
           };
-          return await Block.paginate(query, options);
+          // We are hiding metadata here that could be useful later
+          return { blocks: (await Block.paginate(query, options)).docs };
+
       }
   });
 };

--- a/back/server/models/block.js
+++ b/back/server/models/block.js
@@ -1,0 +1,24 @@
+const Mongoose = require('mongoose');
+const MongoosePaginate = require('mongoose-paginate');
+const Joi = require('joi');
+const Joigoose = require('joigoose')(Mongoose);
+
+var joiBlockSchema = Joi.object({
+    _id: Joi.number().integer().required(),
+    previous: Joi.string().required(),
+    timestamp: Joi.string().required(),
+    witness: Joi.string().required(),
+    next_secret_hash: Joi.string().required(),
+    previous_secret: Joi.string().required(),
+    transaction_merkel_route: Joi.string().required(),
+    extensions: Joi.array().required(),
+    witness_signature: Joi.string().required(),
+    transactions: Joi.array().required()
+});
+
+var mongooseBlockSchema = new Mongoose.Schema(Joigoose.convert(joiBlockSchema));
+mongooseBlockSchema.plugin(MongoosePaginate);
+
+Block = Mongoose.model('Block', mongooseBlockSchema);
+
+module.exports = Block;

--- a/back/yarn.lock
+++ b/back/yarn.lock
@@ -108,6 +108,12 @@ async-each@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
 
+async@2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.1.4.tgz#2d2160c7788032e4dd6cbe2502f1f9a2c8f6cde4"
+  dependencies:
+    lodash "^4.14.0"
+
 async@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.0.tgz#61a29abb6fcc026fea77e56d1c6ec53a795951f4"
@@ -174,6 +180,14 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
+bluebird@3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.0.5.tgz#2ff9d07c9b3edb29d6d280fe07528365e7ecd392"
+
+bluebird@3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.0.tgz#791420d7f551eea2897453a8a77653f96606d67c"
+
 boom@2.x.x:
   version "2.10.1"
   resolved "https://registry.yarnpkg.com/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"
@@ -239,6 +253,10 @@ braces@^2.3.0:
     snapdragon-node "^2.0.1"
     split-string "^3.0.2"
     to-regex "^3.0.1"
+
+bson@~1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/bson/-/bson-1.0.4.tgz#93c10d39eaa5b58415cbc4052f3e53e562b0b72c"
 
 builtin-modules@^1.0.0:
   version "1.1.1"
@@ -466,7 +484,7 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-debug@^2.2.0, debug@^2.3.3:
+debug@2.6.9, debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
@@ -892,7 +910,7 @@ hoek@4.x.x:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.0.tgz#72d9d0754f7fe25ca2d01ad8f8f9a9449a89526d"
 
-hoek@5.x.x:
+hoek@5.x.x, hoek@^5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-5.0.2.tgz#d2f2c95d36fe7189cf8aa8c237abc1950eca1378"
 
@@ -1138,6 +1156,13 @@ joi@13.x.x, joi@^13.1.0:
     isemail "3.x.x"
     topo "3.x.x"
 
+joigoose@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/joigoose/-/joigoose-4.0.0.tgz#def429079180250bf62fcb685b54f4a8306c776d"
+  dependencies:
+    hoek "^5.0.2"
+    joi "^13.1.0"
+
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
@@ -1168,6 +1193,10 @@ jsprim@^1.2.2:
     extsprintf "1.3.0"
     json-schema "0.2.3"
     verror "1.10.0"
+
+kareem@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/kareem/-/kareem-2.0.1.tgz#f17f77e9032f64aa402b334f91fb4407fe4c042c"
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
@@ -1220,6 +1249,10 @@ load-json-file@^1.0.0:
 lodash.assign@^4.0.3, lodash.assign@^4.0.6:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
+
+lodash.get@4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
 
 lodash@^4.14.0:
   version "4.17.4"
@@ -1325,6 +1358,58 @@ mixin-deep@^1.2.0:
 moment@^2.10.6:
   version "2.20.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.20.1.tgz#d6eb1a46cbcc14a2b2f9434112c1ff8907f313fd"
+
+mongodb-core@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/mongodb-core/-/mongodb-core-3.0.1.tgz#ff6dc36ee96ff596953d80a6840d6731bc92efed"
+  dependencies:
+    bson "~1.0.4"
+    require_optional "^1.0.1"
+
+mongodb@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-3.0.1.tgz#278ee8006257ec22798594a6259546825d6de1b2"
+  dependencies:
+    mongodb-core "3.0.1"
+
+mongoose-legacy-pluralize@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.1.tgz#31ae25db45c30f1448c0f93f52769e903367c701"
+
+mongoose-paginate@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/mongoose-paginate/-/mongoose-paginate-5.0.3.tgz#d7ae49ed5bf64f1f7af7620ea865b67058c55371"
+  dependencies:
+    bluebird "3.0.5"
+
+mongoose@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-5.0.1.tgz#ded04311b9f13c8004e2b0097f3a61653a394361"
+  dependencies:
+    async "2.1.4"
+    bson "~1.0.4"
+    kareem "2.0.1"
+    lodash.get "4.4.2"
+    mongodb "3.0.1"
+    mongoose-legacy-pluralize "1.0.1"
+    mpath "0.3.0"
+    mquery "3.0.0-rc0"
+    ms "2.0.0"
+    regexp-clone "0.0.1"
+    sliced "1.0.1"
+
+mpath@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/mpath/-/mpath-0.3.0.tgz#7a58f789e9b5fd3c94520634157960f26bd5ef44"
+
+mquery@3.0.0-rc0:
+  version "3.0.0-rc0"
+  resolved "https://registry.yarnpkg.com/mquery/-/mquery-3.0.0-rc0.tgz#05ec656e92f079828bedf4202e60fb8eaacb9f47"
+  dependencies:
+    bluebird "3.5.0"
+    debug "2.6.9"
+    regexp-clone "0.0.1"
+    sliced "0.0.5"
 
 ms@2.0.0:
   version "2.0.0"
@@ -1690,6 +1775,10 @@ regex-not@^1.0.0:
   dependencies:
     extend-shallow "^2.0.1"
 
+regexp-clone@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/regexp-clone/-/regexp-clone-0.0.1.tgz#a7c2e09891fdbf38fbb10d376fb73003e68ac589"
+
 registry-auth-token@^3.0.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-3.3.1.tgz#fb0d3289ee0d9ada2cbb52af5dfe66cb070d3006"
@@ -1749,6 +1838,17 @@ require-directory@^2.1.1:
 require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
+
+require_optional@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/require_optional/-/require_optional-1.0.1.tgz#4cf35a4247f64ca3df8c2ef208cc494b1ca8fc2e"
+  dependencies:
+    resolve-from "^2.0.0"
+    semver "^5.1.0"
+
+resolve-from@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-2.0.0.tgz#9480ab20e94ffa1d9e80a804c7ea147611966b57"
 
 resolve-url@^0.2.1:
   version "0.2.1"
@@ -1836,6 +1936,14 @@ shot@4.x.x:
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+
+sliced@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/sliced/-/sliced-0.0.5.tgz#5edc044ca4eb6f7816d50ba2fc63e25d8fe4707f"
+
+sliced@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/sliced/-/sliced-1.0.1.tgz#0b3a662b5d04c3177b1926bea82b03f837a2ef41"
 
 snapdragon-node@^2.0.1:
   version "2.1.1"


### PR DESCRIPTION
See #3 

I was curious earlier where the string `id` field in the response came from.  Turns out it's an optional part of the [mongoose-paginate](https://github.com/edwardhotchkiss/mongoose-paginate).
>[leanWithId=true] {Boolean} - If lean and leanWithId are true, adds id field with string representation of _id to every document